### PR TITLE
Fix constant recompilation issue

### DIFF
--- a/lib/tracee.ex
+++ b/lib/tracee.ex
@@ -115,17 +115,21 @@ defmodule Tracee do
     end)
   end
 
-  @assert_receive_timeout Application.compile_env(
-                            :tracee,
-                            :assert_receive_timeout,
-                            Application.compile_env!(:ex_unit, :assert_receive_timeout)
-                          )
+  defp assert_receive_timeout do
+    Application.get_env(
+      :tracee,
+      :assert_receive_timeout,
+      Application.get_env(:ex_unit, :assert_receive_timeout, 100)
+    )
+  end
 
-  @refute_receive_timeout Application.compile_env(
-                            :tracee,
-                            :refute_receive_timeout,
-                            Application.compile_env!(:ex_unit, :refute_receive_timeout)
-                          )
+  defp refute_receive_timeout do
+    Application.get_env(
+      :tracee,
+      :refute_receive_timeout,
+      Application.get_env(:ex_unit, :refute_receive_timeout, 100)
+    )
+  end
 
   @doc """
   Verifies that all expected function calls have been received and nothing else.
@@ -140,19 +144,19 @@ defmodule Tracee do
         Enum.each(expectations, fn
           {_, mfa, 0} ->
             refute_receive {Tracee, ^test, ^mfa},
-                           @refute_receive_timeout,
+                           refute_receive_timeout(),
                            "Expected #{format_mfa(mfa)} NOT to be called in #{inspect(test)}"
 
           {_, mfa, count} ->
             for _ <- 1..count do
               assert_receive {Tracee, ^test, ^mfa},
-                             @assert_receive_timeout,
+                             assert_receive_timeout(),
                              "Expected #{format_mfa(mfa)} to be called in #{inspect(test)}"
             end
         end)
 
         refute_receive {Tracee, _, mfa},
-                       @refute_receive_timeout,
+                       refute_receive_timeout(),
                        "No (more) expectations defined for #{format_mfa(mfa)} in #{inspect(test)}"
 
         GenServer.cast(Handler, {:remove, test})


### PR DESCRIPTION
The issue was caused by using Application.compile_env/3 and Application.compile_env!/2 in module attributes (@assert_receive_timeout and @refute_receive_timeout). These functions create compile-time dependencies on application configuration, causing Mix to recompile the module every time the parent application compiles.

The fix:
- Replaced Application.compile_env with Application.get_env, which reads configuration at runtime instead of compile time
- Converted the module attributes to private functions that are called at runtime
- Updated all usages to call these functions instead of referencing module attributes

This eliminates the compile-time dependency, so tracee will only be compiled once per version/environment as expected.

Fixes #1